### PR TITLE
discord::Error struct, permissions function

### DIFF
--- a/discord/src/lib.rs
+++ b/discord/src/lib.rs
@@ -10,7 +10,12 @@ pub const BASE_URL: &'static str = "https://discordapp.com/api";
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Error<'a> {
-    pub code: u64,
+    // for rate limits
+    pub global: Option<bool>,
+    // in ms
+    pub retry_after: Option<u64>,
+    // max error code is 90001
+    pub code: Option<u32>,
     pub message: &'a str,
 }
 


### PR DESCRIPTION
An update to the ```discord::Error``` struct so that it supports rate-limit errors as well, and adding ```discord_conn::permissions_in``` to calculate the client's permissions in a given channel, used to avoid trying to read from channels the client can't actually see.

Making this PR 70% because I'm bad at git and managing forks, 25% because it's Hacktober